### PR TITLE
Fix zen mode allowed event preference summary.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1039,4 +1039,14 @@
 
     <string name="primary_sub_select_title">Default 3G/LTE subscription</string>
     <string name="select_sim_card">Select SIM card</string>
+
+    <!-- Zen mode allowed event setting summary items -->
+    <!-- [CHAR LIMIT=50] Like zen_mode_reminders, but part of a list, so lower case if needed-->
+    <string name="zen_mode_summary_reminders">reminders</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_events, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_events">events</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_summary_selected_callers, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_selected_callers">selected callers</string>
+    <!-- [CHAR LIMIT=50] Like zen_mode_summary_selected_messages, but part of a list, so lower case if needed -->
+    <string name="zen_mode_summary_selected_messages">selected messages</string>
 </resources>

--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -1453,4 +1453,25 @@ public final class Utils {
                 UserManager.DISALLOW_SMS, userHandle);
         return !callSmsNotAllowed;
     }
+
+    public static String join(Resources res, List<String> items) {
+        final int count = items.size();
+        if (items.isEmpty()) {
+            return null;
+        } else if (count == 1) {
+            return items.get(0);
+        } else if (count == 2) {
+            return res.getString(R.string.join_two_items, items.get(0), items.get(1));
+        } else {
+            String middle = items.get(count - 2);
+            for (int i = count - 3; i > 0; i--) {
+                middle = res.getString(R.string.join_many_items_middle,
+                        items.get(i), middle);
+            }
+            final String allButLast = res.getString(R.string.join_many_items_first,
+                    items.get(0), middle);
+            return res.getString(R.string.join_many_items_last, allButLast,
+                    items.get(count - 1));
+        }
+    }
 }

--- a/src/com/android/settings/notification/ZenModeSettings.java
+++ b/src/com/android/settings/notification/ZenModeSettings.java
@@ -25,6 +25,7 @@ import android.util.SparseArray;
 
 import com.android.internal.logging.MetricsLogger;
 import com.android.settings.R;
+import com.android.settings.Utils;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.search.Indexable;
 import com.android.settings.search.SearchIndexableRaw;
@@ -77,21 +78,21 @@ public class ZenModeSettings extends ZenModeSettingsBase implements Indexable {
     }
 
     private void updatePrioritySettingsSummary() {
-        final boolean callers = mConfig.allowCalls || mConfig.allowRepeatCallers;
-        String s = getResources().getString(R.string.zen_mode_alarms);
-        s = appendLowercase(s, mConfig.allowReminders, R.string.zen_mode_reminders);
-        s = appendLowercase(s, mConfig.allowEvents, R.string.zen_mode_events);
-        s = appendLowercase(s, callers, R.string.zen_mode_selected_callers);
-        s = appendLowercase(s, mConfig.allowMessages, R.string.zen_mode_selected_messages);
-        mPrioritySettings.setSummary(s);
-    }
-
-    private String appendLowercase(String s, boolean condition, int resId) {
-        if (condition) {
-            return getResources().getString(R.string.join_many_items_middle, s,
-                    getResources().getString(resId).toLowerCase());
+        final ArrayList<String> items = new ArrayList<>();
+        items.add(getString(R.string.zen_mode_alarms));
+        if (mConfig.allowReminders) {
+            items.add(getString(R.string.zen_mode_summary_reminders));
         }
-        return s;
+        if (mConfig.allowEvents) {
+            items.add(getString(R.string.zen_mode_summary_events));
+        }
+        if (mConfig.allowCalls || mConfig.allowRepeatCallers) {
+            items.add(getString(R.string.zen_mode_summary_selected_callers));
+        }
+        if (mConfig.allowMessages) {
+            items.add(getString(R.string.zen_mode_summary_selected_messages));
+        }
+        mPrioritySettings.setSummary(Utils.join(getResources(), items));
     }
 
     private static SparseArray<String> allKeyTitles(Context context) {


### PR DESCRIPTION
Simply using lower-cased versions of other strings might work for
English, but not for most other languages.
Also improve formatting of list: Instead of showing 'a, b, c', show 'a,
b and c'.

Change-Id: I7a809e0655cbde3af1695ec3ddf86ec818fb191d