### PR TITLE
Settings: Set regulatory information dialog to non-translatable.

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1063,7 +1063,7 @@
     <string name="zen_mode_summary_selected_messages">selected messages</string>
 
     <!-- About phone settings screen, setting option dialog title to show regulatory information [CHAR LIMIT=25] -->
-    <string name="regulatory_information_dialog_title">@string/regulatory_information</string>
+    <string name="regulatory_information_dialog_title" translatable="false">@string/regulatory_information</string>
 
     <!-- SAR information -->
     <string name="maximum_head_level">Head: %1$s W/kg</string>


### PR DESCRIPTION
Change-Id: I0d5012dc84ec8e6488b0b09d82e2d7bce1afdd38